### PR TITLE
Fix a typo preventing proper npm import

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const classes = require('./lib/classes.json');
 const environments = require('./lib/environments.json');
 
-module.export = {
+module.exports = {
   'contracts': classes,
   'environments': environments,
 };


### PR DESCRIPTION
Fix a typo preventing proper npm import.
"export" should take an "s" at the end, otherwise we are importing an empty object.